### PR TITLE
Added falsehood about addresses not being able to have different countries

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ A list of falsehoods about addresses
   - Ireland would disagree with you (with the exception of Dublin). There are also other [countries without postal codes](https://hellowahab.wordpress.com/2011/05/24/list-of-countries-without-postal-codes/).
 - **The Same Address Can't Be In Different Countries**
   - Except the fact [Büsingen](https://en.wikipedia.org/wiki/B%C3%BCsingen_am_Hochrhein#Post_and_telecommunications) is located in the German/Swiss border area.
+- **It's perfectly fine to use Zip Code instead of Postal Code**
+  - Because Dick Code makes perfect sense. "zip" in Arabic means dick.


### PR DESCRIPTION
Since ["zip" means dick](https://www.reddit.com/r/programming/comments/1fc147/falsehoods_programmers_believe_about_addresses/ca96s7e), it would be less offensive to just use postal code instead.
