### PR TITLE
Added falsehood that a person will only have one address

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ A list of falsehoods about addresses
   - Except the fact [Büsingen](https://en.wikipedia.org/wiki/B%C3%BCsingen_am_Hochrhein#Post_and_telecommunications) is located in the German/Swiss border area.
 - **It's perfectly fine to use Zip Code instead of Postal Code**
   - Because Dick Code makes perfect sense. "zip" in Arabic means dick.
+- **A person can only have one address**
+  - A person can either own multiple properties or a child could have an address with mother, an address with a father, etc.


### PR DESCRIPTION
So a system should allow for a person to have multiple addresses and if needed a note column for someone reviewing the address (for example if someone only lives in a certain address part of the year and then another address for the rest of the year and a package needs to be sent to that person - it would allow for the package to be sent to the correct location for that person)
