### PR TITLE
Added falsehood that Portal codes should be stored as an int in a database

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ A list of falsehoods about addresses
   - A person can either own multiple properties or a child could have an address with mother, an address with a father, etc.
 - **An Address will have a street name**
   - [Japan's addressing system](https://en.wikipedia.org/wiki/Japanese_addressing_system) is pretty complex and most Japanese streets do not have names.
+- **Postal codes should be stored in a database using an integer column**
+  - Reminds me when I inherited a project that the previous developer did this and then the client sent over data with Massachusetts ZIP Codes which start with 0.
+- **Postal codes won't start with a zero**
+  - See falsehood about storing postal codes using an integer. Norway also has postcodes which can start with a 0 (0368 is not the same as 368).  
+- **An address postal code can't contain a space**
+  - Sweden has a space after the first digit (5 4367).


### PR DESCRIPTION
Also include related falsehoods of why it shouldn't be stored as an int, such as postal codes can't start with 0 or can't contain a space. Thanks for reddit user [Gundersen](https://www.reddit.com/r/programming/comments/1fc147/falsehoods_programmers_believe_about_addresses/ca9ej0i) for the information in Sweden.
